### PR TITLE
Test for principal URL Encoding issues [WIP]

### DIFF
--- a/src/test/java/com/purbon/kafka/topology/integration/MDSApiClientRbacIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/MDSApiClientRbacIT.java
@@ -130,6 +130,32 @@ public class MDSApiClientRbacIT extends MDSBaseTest {
   }
 
   @Test
+  public void testBindSubjectRoleURLEncodingNeeded() throws IOException {
+    apiClient.setBasicAuth(new BasicAuth(mdsUser, mdsPassword));
+    apiClient.authenticate();
+    apiClient.setKafkaClusterId(getKafkaClusterID());
+    apiClient.setSchemaRegistryClusterID("schema-registry");
+
+    String principal = "Group:ReadOnly and Security" + System.currentTimeMillis();
+    String subject = "topic-value";
+
+    TopologyAclBinding binding =
+            apiClient
+                    .bind(principal, DEVELOPER_READ)
+                    .forSchemaSubject(subject)
+                    .apply("Subject", subject);
+
+    apiClient.bindRequest(binding);
+
+    Map<String, Map<String, String>> clusters =
+            apiClient.withClusterIDs().forKafka().forSchemaRegistry().asMap();
+
+    List<String> roles = apiClient.lookupRoles(principal, clusters);
+    assertEquals(1, roles.size());
+    assertTrue(roles.contains(DEVELOPER_READ));
+  }
+
+  @Test
   public void testBindResourceOwnerRole() throws IOException {
     apiClient.setBasicAuth(new BasicAuth(mdsUser, mdsPassword));
     apiClient.authenticate();


### PR DESCRIPTION
AD/LDAP mapped principals support a richer charset than URLs (e.g. spaces) so they need to be encoded before making the request to MDS API. 

Currently, trying to use a principal with special characters fails with the following error: 

```
java.lang.IllegalArgumentException: Illegal character in path at index 60: http://localhost:8090/security/1.0/principals/Group:ReadOnly and Security1697538745244/roles/DeveloperRead/bindings

	at java.base/java.net.URI.create(URI.java:906)
	at com.purbon.kafka.topology.clients.JulieHttpClient.setupARequest(JulieHttpClient.java:71)
	at com.purbon.kafka.topology.clients.JulieHttpClient.postRequest(JulieHttpClient.java:176)
	at com.purbon.kafka.topology.clients.JulieHttpClient.doPost(JulieHttpClient.java:171)
	at com.purbon.kafka.topology.api.mds.MDSApiClient.bindRequest(MDSApiClient.java:163)
	at com.purbon.kafka.topology.integration.MDSApiClientRbacIT.testBindSubjectRoleURLEncodingNeeded(MDSApiClientRbacIT.java:148)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: java.net.URISyntaxException: Illegal character in path at index 60: http://localhost:8090/security/1.0/principals/Group:ReadOnly and Security1697538745244/roles/DeveloperRead/bindings
	at java.base/java.net.URI$Parser.fail(URI.java:2973)
	at java.base/java.net.URI$Parser.checkChars(URI.java:3144)
	at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3226)
	at java.base/java.net.URI$Parser.parse(URI.java:3174)
	at java.base/java.net.URI.<init>(URI.java:623)
	at java.base/java.net.URI.create(URI.java:904)
	... 31 more
```